### PR TITLE
Add Squaremap claim markers support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,9 @@ dependencies {
 
     compileOnly("de.bluecolored:bluemap-api:2.7.8")
     compileOnly("com.flowpowered:flow-math:1.0.3")
-    compileOnly("xyz.jpenilla:squaremap-api:1.3.15")
+    compileOnly("xyz.jpenilla:squaremap-api:1.3.15") {
+        exclude(group = "net.kyori")
+    }
 
     implementation("org.bstats:bstats-bukkit:3.2.1")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     compileOnly("de.bluecolored:bluemap-api:2.7.8")
     compileOnly("com.flowpowered:flow-math:1.0.3")
+    compileOnly("xyz.jpenilla:squaremap-api:1.3.15")
 
     implementation("org.bstats:bstats-bukkit:3.2.1")
 }

--- a/src/main/kotlin/com/foenichs/bonfire/Bonfire.kt
+++ b/src/main/kotlin/com/foenichs/bonfire/Bonfire.kt
@@ -55,18 +55,27 @@ class Bonfire : JavaPlugin() {
         visualService = VisualService(this, registry, protectionService, limitService)
         val migrationService = MigrationService(this, db, registry, protectionService)
 
-        // Initialize BlueMap Service (optional)
+        // Initialize map integrations (optional)
         val blueMapService = if (Bukkit.getPluginManager().isPluginEnabled("BlueMap")) {
             BlueMapService(this, registry)
         } else {
             null
         }
+        val squaremapService = if (Bukkit.getPluginManager().isPluginEnabled("squaremap")) {
+            SquaremapService(this, registry).also { it.refreshAll() }
+        } else {
+            null
+        }
+        val mapServices: List<ClaimMapService> = listOfNotNull(
+            blueMapService?.let(::BlueMapClaimMapService),
+            squaremapService
+        )
 
         // Initialize Listener first (ClaimService needs it for cache updates)
         val playerListener = PlayerListener(this, registry, messenger, visualService)
 
         // Initialize Logic Service
-        val claimService = ClaimService(registry, db, messenger, limitService, visualService, playerListener, blueMapService, migrationService, this)
+        val claimService = ClaimService(registry, db, messenger, limitService, visualService, playerListener, mapServices, migrationService, this)
 
         // Register Command Tree
         lifecycleManager.registerEventHandler(LifecycleEvents.COMMANDS) { event ->
@@ -74,7 +83,7 @@ class Bonfire : JavaPlugin() {
             BonfireCommand({
                 reloadConfig()
                 limitService.updateConfig(config)
-                blueMapService?.refreshAll()
+                mapServices.forEach { it.refreshAll() }
             }, claimService).register(event.registrar())
         }
 

--- a/src/main/kotlin/com/foenichs/bonfire/service/ClaimMapService.kt
+++ b/src/main/kotlin/com/foenichs/bonfire/service/ClaimMapService.kt
@@ -1,0 +1,21 @@
+package com.foenichs.bonfire.service
+
+import com.foenichs.bonfire.model.Claim
+import java.util.UUID
+
+interface ClaimMapService {
+    fun refreshAll()
+    fun updateClaim(claim: Claim)
+    fun removeClaim(id: Int, worldId: UUID)
+    fun shutdown() {}
+}
+
+class BlueMapClaimMapService(
+    private val delegate: BlueMapService
+) : ClaimMapService {
+    override fun refreshAll() = delegate.refreshAll()
+
+    override fun updateClaim(claim: Claim) = delegate.updateClaim(claim)
+
+    override fun removeClaim(id: Int, worldId: UUID) = delegate.removeClaim(id, worldId)
+}

--- a/src/main/kotlin/com/foenichs/bonfire/service/ClaimPolygonTracer.kt
+++ b/src/main/kotlin/com/foenichs/bonfire/service/ClaimPolygonTracer.kt
@@ -1,0 +1,134 @@
+package com.foenichs.bonfire.service
+
+import com.foenichs.bonfire.model.Claim
+import kotlin.math.abs
+
+data class ClaimMapPoint(val x: Double, val z: Double)
+data class ClaimPolygonData(val outer: List<ClaimMapPoint>, val holes: List<List<ClaimMapPoint>>)
+
+object ClaimPolygonTracer {
+    private const val EPSILON = 0.01
+
+    private data class Segment(val x1: Double, val z1: Double, val x2: Double, val z2: Double)
+
+    private enum class Direction {
+        EAST,
+        SOUTH,
+        WEST,
+        NORTH;
+
+        fun priorityTo(next: Direction): Int {
+            val turn = (next.ordinal - ordinal + 4) % 4
+            return when (turn) {
+                3 -> 0 // left
+                0 -> 1 // straight
+                1 -> 2 // right
+                else -> 3 // back
+            }
+        }
+    }
+
+    fun trace(claim: Claim): ClaimPolygonData? {
+        if (claim.chunks.isEmpty()) return null
+
+        val chunkSet = claim.chunks
+            .map { it.chunkKey.toInt() to (it.chunkKey shr 32).toInt() }
+            .toSet()
+        val segments = HashSet<Segment>()
+
+        chunkSet.forEach { (cx, cz) ->
+            val minX = cx * 16.0
+            val maxX = minX + 16.0
+            val minZ = cz * 16.0
+            val maxZ = minZ + 16.0
+
+            if (!chunkSet.contains(cx to cz - 1)) segments.add(Segment(minX, minZ, maxX, minZ))
+            if (!chunkSet.contains(cx to cz + 1)) segments.add(Segment(maxX, maxZ, minX, maxZ))
+            if (!chunkSet.contains(cx - 1 to cz)) segments.add(Segment(minX, maxZ, minX, minZ))
+            if (!chunkSet.contains(cx + 1 to cz)) segments.add(Segment(maxX, minZ, maxX, maxZ))
+        }
+
+        if (segments.isEmpty()) return null
+
+        val loops = mutableListOf<List<ClaimMapPoint>>()
+
+        while (segments.isNotEmpty()) {
+            val points = mutableListOf<ClaimMapPoint>()
+            val startSegment = segments.first()
+            var currentSegment = startSegment
+            var closed = false
+
+            points.add(ClaimMapPoint(currentSegment.x1, currentSegment.z1))
+            segments.remove(currentSegment)
+
+            while (true) {
+                val nextPoint = ClaimMapPoint(currentSegment.x2, currentSegment.z2)
+                if (samePoint(nextPoint, points.first())) {
+                    closed = true
+                    break
+                }
+
+                points.add(nextPoint)
+
+                val next = findNextSegment(segments, currentSegment) ?: break
+                currentSegment = next
+                segments.remove(next)
+            }
+
+            if (closed && points.size >= 3) {
+                loops.add(optimizePoints(points))
+            }
+        }
+
+        if (loops.isEmpty()) return null
+
+        val outer = loops.maxByOrNull { abs(signedArea(it)) } ?: return null
+        val holes = loops.filter { it !== outer }
+        return ClaimPolygonData(outer, holes)
+    }
+
+    private fun findNextSegment(segments: Set<Segment>, current: Segment): Segment? {
+        val currentDirection = directionOf(current)
+
+        return segments.asSequence()
+            .filter {
+                abs(it.x1 - current.x2) < EPSILON &&
+                    abs(it.z1 - current.z2) < EPSILON
+            }
+            // Prefer left/straight/right turns so diagonally touching boundaries stay separate simple loops.
+            .minByOrNull { currentDirection.priorityTo(directionOf(it)) }
+    }
+
+    private fun directionOf(segment: Segment): Direction = when {
+        segment.x2 > segment.x1 -> Direction.EAST
+        segment.z2 > segment.z1 -> Direction.SOUTH
+        segment.x2 < segment.x1 -> Direction.WEST
+        else -> Direction.NORTH
+    }
+
+    private fun samePoint(a: ClaimMapPoint, b: ClaimMapPoint): Boolean =
+        abs(a.x - b.x) < EPSILON && abs(a.z - b.z) < EPSILON
+
+    private fun signedArea(points: List<ClaimMapPoint>): Double {
+        var area = 0.0
+        for (i in points.indices) {
+            val current = points[i]
+            val next = points[(i + 1) % points.size]
+            area += current.x * next.z - next.x * current.z
+        }
+        return area / 2.0
+    }
+
+    private fun optimizePoints(input: List<ClaimMapPoint>): List<ClaimMapPoint> {
+        if (input.size < 3) return input
+
+        return input.filterIndexed { index, current ->
+            val previous = input[(index - 1 + input.size) % input.size]
+            val next = input[(index + 1) % input.size]
+
+            val vertical = abs(previous.x - current.x) < EPSILON && abs(current.x - next.x) < EPSILON
+            val horizontal = abs(previous.z - current.z) < EPSILON && abs(current.z - next.z) < EPSILON
+            !vertical && !horizontal
+        }
+    }
+}

--- a/src/main/kotlin/com/foenichs/bonfire/service/ClaimService.kt
+++ b/src/main/kotlin/com/foenichs/bonfire/service/ClaimService.kt
@@ -22,7 +22,7 @@ class ClaimService(
     private val limits: LimitService,
     private val visualService: VisualService,
     private val playerListener: PlayerListener,
-    private val blueMapService: BlueMapService?,
+    private val mapServices: List<ClaimMapService>,
     private val migrationService: MigrationService,
     private val plugin: Bonfire
 ) {
@@ -52,7 +52,7 @@ class ClaimService(
             adj.size == 1 -> {
                 val c = adj.first(); val pos = ChunkPos(w, k); c.chunks.add(pos); db.addChunk(c.id!!, pos)
                 migrationService.processChunk(ch)
-                blueMapService?.updateClaim(c)
+                updateClaimMarkers(c)
                 msg.send(p, Component.text("Successfully claimed this chunk and added it to your claim."))
                 finishAction(p, c.owner)
             }
@@ -77,7 +77,7 @@ class ClaimService(
                     val claim = Claim(id, p.uniqueId, mutableSetOf(pos), defBreak, defInteract, defEntity)
                     registry.add(claim); db.addChunk(id, pos); db.updateRules(claim)
                     migrationService.processChunk(ch)
-                    blueMapService?.updateClaim(claim)
+                    updateClaimMarkers(claim)
                     msg.send(p, Component.text("Successfully claimed this chunk and created a new claim."))
                     finishAction(p, claim.owner)
                 }
@@ -113,7 +113,7 @@ class ClaimService(
         val oldOwnerId = claim.owner
         claim.owner = offline.uniqueId
         db.updateOwner(claim.id!!, offline.uniqueId)
-        blueMapService?.updateClaim(claim)
+        updateClaimMarkers(claim)
 
         msg.send(p, Component.text("Successfully transferred the ownership of this claim to ${offline.name}."))
         finishActionForClaim(claim)
@@ -243,9 +243,9 @@ class ClaimService(
 
             db.deleteClaim(id)
             main.chunks.addAll(d.chunks); main.trustedAlways.addAll(d.trustedAlways); main.trustedOnline.addAll(d.trustedOnline)
-            registry.remove(d); blueMapService?.removeClaim(id, wid)
+            registry.remove(d); removeClaimMarkers(id, wid)
         }
-        blueMapService?.updateClaim(main)
+        updateClaimMarkers(main)
         msg.send(p, Component.text("Successfully merged your claims.")); finishAction(p, main.owner)
         finishActionForClaim(main)
     }
@@ -254,14 +254,22 @@ class ClaimService(
         val wid = c.chunks.first().worldUuid; val id = c.id!!
         db.deleteClaim(id); registry.remove(c)
         c.chunks.forEach { db.removeFromQueue(it.worldUuid, it.chunkKey) }
-        blueMapService?.removeClaim(id, wid)
+        removeClaimMarkers(id, wid)
         refreshPlayersAfterRemoval(c)
     }
 
     private fun handleChunkUnclaim(c: Claim, pos: ChunkPos) {
         c.chunks.remove(pos); db.removeChunk(c.id!!, pos)
         db.removeFromQueue(pos.worldUuid, pos.chunkKey)
-        blueMapService?.updateClaim(c)
+        updateClaimMarkers(c)
+    }
+
+    private fun updateClaimMarkers(claim: Claim) {
+        mapServices.forEach { it.updateClaim(claim) }
+    }
+
+    private fun removeClaimMarkers(id: Int, worldId: UUID) {
+        mapServices.forEach { it.removeClaim(id, worldId) }
     }
 
     private fun refreshPlayersAfterRemoval(c: Claim) {

--- a/src/main/kotlin/com/foenichs/bonfire/service/SquaremapService.kt
+++ b/src/main/kotlin/com/foenichs/bonfire/service/SquaremapService.kt
@@ -1,0 +1,136 @@
+package com.foenichs.bonfire.service
+
+import com.foenichs.bonfire.Bonfire
+import com.foenichs.bonfire.model.Claim
+import com.foenichs.bonfire.storage.ClaimRegistry
+import org.bukkit.Bukkit
+import xyz.jpenilla.squaremap.api.BukkitAdapter
+import xyz.jpenilla.squaremap.api.Key
+import xyz.jpenilla.squaremap.api.MapWorld
+import xyz.jpenilla.squaremap.api.Point
+import xyz.jpenilla.squaremap.api.SimpleLayerProvider
+import xyz.jpenilla.squaremap.api.SquaremapProvider
+import xyz.jpenilla.squaremap.api.marker.Marker
+import xyz.jpenilla.squaremap.api.marker.MarkerOptions
+import java.awt.Color
+import java.util.UUID
+
+class SquaremapService(
+    private val plugin: Bonfire,
+    private val registry: ClaimRegistry
+) : ClaimMapService {
+    private val layerKey = Key.of("bonfire_claims")
+    private val providers = mutableMapOf<UUID, Pair<MapWorld, SimpleLayerProvider>>()
+
+    override fun refreshAll() {
+        clearLayers()
+        if (!plugin.config.getBoolean("squaremap.enable-markers", true)) return
+
+        val claimsByWorld = registry.getAll().groupBy { it.chunks.firstOrNull()?.worldUuid }
+
+        SquaremapProvider.get().mapWorlds().forEach { mapWorld ->
+            val worldId = BukkitAdapter.bukkitWorld(mapWorld).uid
+            val provider = createProvider(mapWorld, worldId)
+
+            claimsByWorld[worldId].orEmpty().forEach { claim ->
+                createMarker(provider, claim)
+            }
+        }
+    }
+
+    override fun updateClaim(claim: Claim) {
+        if (!plugin.config.getBoolean("squaremap.enable-markers", true)) return
+        if (claim.chunks.isEmpty()) return
+
+        val worldId = claim.chunks.first().worldUuid
+        val provider = getOrCreateProvider(worldId) ?: return
+        createMarker(provider, claim)
+    }
+
+    override fun removeClaim(id: Int, worldId: UUID) {
+        providers[worldId]?.second?.removeMarker(markerKey(id))
+    }
+
+    override fun shutdown() {
+        clearLayers()
+    }
+
+    private fun createMarker(provider: SimpleLayerProvider, claim: Claim) {
+        val id = claim.id ?: return
+        val polygon = ClaimPolygonTracer.trace(claim) ?: return
+        val ownerName = Bukkit.getOfflinePlayer(claim.owner).name ?: "Unknown"
+        val labelTemplate = plugin.config.getString("squaremap.label", "Claimed by \$name")!!
+        val label = labelTemplate.replace("\$name", ownerName)
+
+        val outer = polygon.outer.map { Point.of(it.x, it.z) }
+        val holes = polygon.holes.map { hole -> hole.map { Point.of(it.x, it.z) } }
+        val marker = Marker.polygon(outer, holes)
+
+        marker.markerOptions(
+            MarkerOptions.builder()
+                .strokeColor(readColor("squaremap.stroke-color", Color(255, 221, 161)))
+                .strokeWeight(plugin.config.getInt("squaremap.stroke-weight", 2).coerceAtLeast(1))
+                .strokeOpacity(plugin.config.getDouble("squaremap.stroke-opacity", 0.8).coerceIn(0.0, 1.0))
+                .fillColor(readColor("squaremap.fill-color", Color(255, 221, 161)))
+                .fillOpacity(plugin.config.getDouble("squaremap.fill-opacity", 0.15).coerceIn(0.0, 1.0))
+                .clickTooltip(label)
+        )
+
+        provider.addMarker(markerKey(id), marker)
+    }
+
+    private fun getOrCreateProvider(worldId: UUID): SimpleLayerProvider? {
+        providers[worldId]?.let { return it.second }
+
+        val mapWorld = SquaremapProvider.get().mapWorlds().firstOrNull {
+            BukkitAdapter.bukkitWorld(it).uid == worldId
+        } ?: return null
+
+        return createProvider(mapWorld, worldId)
+    }
+
+    private fun createProvider(mapWorld: MapWorld, worldId: UUID): SimpleLayerProvider {
+        if (mapWorld.layerRegistry().hasEntry(layerKey)) {
+            mapWorld.layerRegistry().unregister(layerKey)
+        }
+
+        val provider = SimpleLayerProvider.builder(
+            plugin.config.getString("squaremap.layer-label", "Bonfire Claims")!!
+        )
+            .showControls(true)
+            .defaultHidden(plugin.config.getBoolean("squaremap.default-hidden", false))
+            .layerPriority(plugin.config.getInt("squaremap.layer-priority", 50))
+            .zIndex(plugin.config.getInt("squaremap.z-index", 50))
+            .build()
+
+        mapWorld.layerRegistry().register(layerKey, provider)
+        providers[worldId] = mapWorld to provider
+        return provider
+    }
+
+    private fun clearLayers() {
+        providers.values.forEach { (mapWorld, provider) ->
+            provider.clearMarkers()
+            if (mapWorld.layerRegistry().hasEntry(layerKey)) {
+                mapWorld.layerRegistry().unregister(layerKey)
+            }
+        }
+        providers.clear()
+    }
+
+    private fun markerKey(id: Int): Key = Key.of("claim_$id")
+
+    private fun readColor(path: String, fallback: Color): Color {
+        val rgb = plugin.config.getString(path)
+            ?.split(",")
+            ?.mapNotNull { it.trim().toIntOrNull() }
+            ?.takeIf { it.size == 3 }
+            ?: return fallback
+
+        return Color(
+            rgb[0].coerceIn(0, 255),
+            rgb[1].coerceIn(0, 255),
+            rgb[2].coerceIn(0, 255)
+        )
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,3 +35,23 @@ bluemap:
   accent-color: 255, 221, 161
   # If the camera is further to this marker than this distance, it will be hidden
   view-distance: 1000
+
+# Configs for squaremap claim markers, if squaremap is installed
+squaremap:
+  # If set to false, the Bonfire Claims layer won't be shown
+  enable-markers: true
+  # Layer name displayed in squaremap's layer control
+  layer-label: Bonfire Claims
+  # $name gets replaced with the name of the claim owner
+  label: Claimed by $name
+  # Whether the layer should be hidden when the map is first opened
+  default-hidden: false
+  # RGB colors and opacity for claim borders and fill
+  stroke-color: 255, 221, 161
+  stroke-opacity: 0.8
+  stroke-weight: 2
+  fill-color: 255, 221, 161
+  fill-opacity: 0.15
+  # Ordering relative to other squaremap layers
+  layer-priority: 50
+  z-index: 50

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,4 +6,4 @@ prefix: Bonfire
 authors: [ foenichs ]
 description: Easily claim chunks and manage how others can interact with them.
 website: foenichs.com
-softdepend: [BlueMap]
+softdepend: [BlueMap, squaremap]


### PR DESCRIPTION
## Summary

Adds native Squaremap support for displaying Bonfire claims.

The implementation keeps the existing BlueMap integration unchanged and adds Squaremap as an additional optional map provider.

## Changes

* add `squaremap-api` as a compile-only dependency
* add `squaremap` as a soft dependency
* add `SquaremapService` for rendering claim polygons
* add Squaremap configuration options
* update claim markers when claims are created, changed, merged or removed
* add a small shared map-service abstraction so BlueMap and Squaremap can be updated through the same claim logic
* keep the existing BlueMap implementation and behavior unchanged

## Testing

Tested manually on a Paper server with Squaremap installed.

Verified that:

* existing claims are displayed after server startup
* new claims appear on the map
* expanding and shrinking claims updates their shape
* deleted claims are removed from the map
* merged claims are updated correctly
* claim ownership changes update marker labels
* configuration reload refreshes Squaremap markers

The integration is optional and Bonfire continues to work normally when Squaremap is not installed.